### PR TITLE
add cssSpritesheetName in gulp sprite task

### DIFF
--- a/gulp/tasks/sprite.coffee
+++ b/gulp/tasks/sprite.coffee
@@ -11,9 +11,10 @@ createSpriteTask = (filePath) ->
         spriteData = gulp.src(filePath[1] + filePath[2] + '/*.png')
             .pipe($.plumber())
             .pipe($.spritesmith({
-                imgName: filePath[2] + '.png',
-                cssName: filePath[2] + '.scss',
+                imgName: filePath[2] + '.png'
+                cssName: filePath[2] + '.scss'
                 imgPath: '../img/' + filePath[2] + '.png'
+                cssSpritesheetName: filePath[2]
             }))
         spriteData.img.pipe(gulp.dest(config.path.image))
         spriteData.css.pipe(gulp.dest(config.path.scss))

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-uglify": "^1.0.1",
     "gulp-uncss": "^0.5.0",
     "gulp-useref": "^1.0.2",
-    "gulp.spritesmith": "^1.4.0",
+    "gulp.spritesmith": "4.0.0",
     "jshint-stylish": "^1.0.0",
     "lodash": "^3.5.0",
     "main-bower-files": "^2.1.0",


### PR DESCRIPTION
gulp spriteタスクにて、ファイル名の一覧を配列化してくれるcssSpritesheetNameを使うため、gulp.spritesmithのバージョンを上げ、タスクの方にも追記しました。
