### PR TITLE
modify sprite generator algorithm, and add padding

### DIFF
--- a/gulp/tasks/sprite.coffee
+++ b/gulp/tasks/sprite.coffee
@@ -14,6 +14,8 @@ createSpriteTask = (filePath) ->
                 imgName: filePath[2] + '.png',
                 cssName: filePath[2] + '.scss',
                 imgPath: '../img/' + filePath[2] + '.png'
+                algorithm: 'binary-tree'
+                padding: 2
             }))
         spriteData.img.pipe(gulp.dest(config.path.image))
         spriteData.css.pipe(gulp.dest(config.path.scss))

--- a/gulp/tasks/sprite.coffee
+++ b/gulp/tasks/sprite.coffee
@@ -15,7 +15,7 @@ createSpriteTask = (filePath) ->
                 cssName: filePath[2] + '.scss',
                 imgPath: '../img/' + filePath[2] + '.png'
                 algorithm: 'binary-tree'
-                padding: 2
+                padding: 4
             }))
         spriteData.img.pipe(gulp.dest(config.path.image))
         spriteData.css.pipe(gulp.dest(config.path.scss))


### PR DESCRIPTION
ブラウザによっては読み込める画像最大幅が制限されていたはずなので、なるだけそれを避けるように、
algorithmを 'binary-tree'に変更しました。

また、Retina画像をsprite化したときに奇数ピクセルだとズレて前後の画像が見えてしまう問題があったため、padding: 2pxを追記しました。
